### PR TITLE
Terraform installation on vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = "hashicorp/bionic64"
   config.vm.hostname = "golang"
  
+  config.vm.provision "shell", path: "vagrant_scripts/install_terraform_11.sh"
+
   config.vm.provider "virtualbox" do |v|
     v.memory = 1024*2
     v.cpus = 2

--- a/scripts/install_terraform_11.sh
+++ b/scripts/install_terraform_11.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export DEBIAN_FRONTEND=noninteractive
+
+# install terraform
+curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
+apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+
+apt-get update -y
+apt-get install -y terraform=0.11.15

--- a/vagrant_scripts/install_terraform_11.sh
+++ b/vagrant_scripts/install_terraform_11.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export DEBIAN_FRONTEND=noninteractive
+
+# install terraform
+curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
+apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+
+apt-get update -y
+apt-get install -y terraform=0.11.15


### PR DESCRIPTION
Install terraform 11 on the vagrant box. 

We need terraform 11 because the custom plugin requires terraform version 11