### PR TITLE
Build terraform custom plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ vagrant up
 
 
 ## TODO
-- [ ] build the custom plugin
 - [ ] run terraform
 
 ## DONE
@@ -19,3 +18,4 @@ vagrant up
 - [x] install terraform version 11
 - [x] install gcc
 - [x] install go version 1.10
+- [x] build the custom plugin

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: "vagrant_scripts/install_terraform_11.sh"
   config.vm.provision "shell", path: "vagrant_scripts/install_gcc.sh"
   config.vm.provision "shell", path: "vagrant_scripts/install_go_1.10.sh"
+  config.vm.provision "shell", path: "vagrant_scripts/build_plugin.sh", privileged: false
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 1024*2

--- a/vagrant_scripts/build_plugin.sh
+++ b/vagrant_scripts/build_plugin.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# we are building the plugin of the github repository
+# 
+
+export DEBIAN_FRONTEND=noninteractive
+
+# get the files from the github repository
+go get github.com/petems/terraform-provider-extip
+
+# go the directory which has been created
+pushd ~/go/src/github.com/petems/terraform-provider-extip
+
+# build the plugin
+make build
+
+# create the directory where to store the plugin
+mkdir -p /vagrant/terraform.d/plugins/linux_amd64
+
+# copy the plugin to the directory which we are going to use with terraform
+cp ~/go/bin/terraform-provider-extip /vagrant/terraform.d/plugins/linux_amd64/


### PR DESCRIPTION
We are building the custom terraform plugin from this github repository
https://github.com/petems/terraform-provider-extip#readme

The build_plugin.sh script will download the repository and build the plugin. 
The plugin will be copied to the /vagrant/terraform.d/plugins/linux_amd64 directory where we can use it in the next script when using terraform